### PR TITLE
Remove duplicate group translation

### DIFF
--- a/alphav-dance/en.ini
+++ b/alphav-dance/en.ini
@@ -23,7 +23,6 @@ length=Length
 search=Search
 # The following modes are exclusive to the search feature.
 subtitle=Subtitle
-group=group
 meter=Meter
 
 [ScreenTitleMenu]

--- a/alphav-dance/es.ini
+++ b/alphav-dance/es.ini
@@ -23,7 +23,6 @@ length=Duración
 search=Busqueda
 # The following modes are exclusive to the search feature.
 subtitle=Subtítulo
-pack=Paquete
 meter=Dificultad
 
 [SearchSongWide]

--- a/alphav-dance/ja.ini
+++ b/alphav-dance/ja.ini
@@ -22,7 +22,6 @@ length=長さ
 search=検索
 # The following modes are exclusive to the search feature.
 subtitle=サブタイトル
-group=グループ
 meter=難易度
 
 [ScreenTitleMenu]

--- a/alphav-dance/pl.ini
+++ b/alphav-dance/pl.ini
@@ -32,7 +32,6 @@ length=Długość
 search=Szukaj
 # Wyszukiwarka
 subtitle=Podtytuł
-pack=Grupa
 meter=Poziom
 
 [ScreenTitleMenu]

--- a/alphav-dance/pt-BR.ini
+++ b/alphav-dance/pt-BR.ini
@@ -22,7 +22,6 @@ length=Duração
 search=Pesquisar
 # The following modes are exclusive to the search feature.
 subtitle=Sub-Título
-group=grupo
 meter=medida
 
 [ScreenTitleMenu]


### PR DESCRIPTION
There's a "pack" translation only in other languages, but it is not in English so I removed it. I'd assume it's the same as "group" (based on the pl translation).

Noticed because of this (removing the duplicate "group" fixes the casing):
![Screenshot 2025-03-30 at 1 51 56 PM](https://github.com/user-attachments/assets/3c5189ca-0aa1-460a-ae62-f66292a231ad)
